### PR TITLE
Figure out supervisor trees

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+---
+language: node_js
+node_js:
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "6"
+
+sudo: false
+dist: trusty
+
+addons:
+  chrome: stable
+
+cache:
+  directories:
+    - $HOME/.npm
+
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+  matrix:
+    # we recommend new addons test the current and previous LTS
+    # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=ember-default
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
+before_install:
+  - npm config set spin false
+  - npm install -g npm@6
+  - npm --version
+
+script:
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/src/run-async.ts
+++ b/src/run-async.ts
@@ -19,8 +19,8 @@ import errorCode from './error-code';
 export async function _runAsync<T>(
   asyncFn: AsyncFn<T>,
   args: Array<any>,
-  failStateFn: FailStateFn<T>,
-  successStateFn: SuccessStateFn<T>
+  failStateFn: FailStateFn<T> = defaultRunSpecFailFn,
+  successStateFn: SuccessStateFn<T> = defaultRunSpecSuccessFn
 ): Promise<RunAttempt<T>> {
   const runResults: Array<RunAttempt<T>> = [];
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,0 +1,24 @@
+import perfStart from "./perf-start";
+import { 
+  AsyncFn,
+  RunFailure,
+  RunSuccess,
+  RunAttempt
+} from './types';
+import runAsync from "./run-async";
+
+export default class Task<T> {
+  asyncFn: AsyncFn<T>;
+  fnArgs: Array<any>;
+
+  constructor(asyncFn: AsyncFn<T>, fnArgs: Array<any> = []) {
+    this.asyncFn = asyncFn;
+    this.fnArgs = fnArgs;
+  }
+
+  perform(): Promise<T> {
+    const { asyncFn, fnArgs } = this;
+
+    return runAsync(asyncFn, fnArgs)
+  }
+}

--- a/test/integration/netflix.test.js
+++ b/test/integration/netflix.test.js
@@ -1,0 +1,49 @@
+/**
+ * Acquire Stream Integration Test
+ *
+ * Suppose we're trying to building the core stream-
+ * acquisition functionality of a netflix-like video
+ * streaming service.
+ *
+ * Before an user can start stream, we must check his
+ * subscription, account restriction, our streaming-plugin
+ * status, video availability on the remote server,
+ * and start the stream if and only if everything is lined up
+ */
+const waitMS = n => new Promise(resolve => setTimeout(resolve, n));
+
+const EXAMPLE_MOVIE = {
+  id: 'sony-pic-2017',
+  name: 'Emoji Movie 2',
+  rating: 'pg'
+};
+
+const EXAMPLE_USER = {
+  id: '666',
+  name: 'Chad Masterson',
+  hasSubscription: true
+};
+
+const EXAMPLE_CHILD = {
+  id: '666-2',
+  name: 'Beta Virginia',
+  hasSubscription: true,
+  restrictions: [
+    'under-18'
+  ]
+};
+
+class MovieServer {
+  static get db() {
+    return {
+      'sony-pic-2017': EXAMPLE_MOVIE
+    };
+  }
+  async request(id) {
+    await waitMS(5);
+    return MovieServer.db[id];
+  }
+}
+async function startStream(movieID, userID) {
+
+}


### PR DESCRIPTION
Background
===
`runAsync` is great and all, but what if we need to nest `runAsync`s inside other `runAsync`s and run all of that in a sensible and composable way?

Elixir / Erlang solves this with supervisor processes, so here in JS land, I will try to implement something similar

TODOs
===
- [ ] start an integration test to try to spec out how I'd like to specify supervisors

References
===
- Elixir supervisor docs https://hexdocs.pm/elixir/Supervisor.html#content